### PR TITLE
Multiple inheritance for abstract configs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     `maven-publish`
 }
 
-val versionObj = Version("1", "4", "1", false)
+val versionObj = Version("1", "4", "0", false)
 
 group = "com.dfsek"
 version = versionObj

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     `maven-publish`
 }
 
-val versionObj = Version("1", "3", "1", false)
+val versionObj = Version("1", "4", "1", false)
 
 group = "com.dfsek"
 version = versionObj

--- a/src/main/java/com/dfsek/tectonic/abstraction/AbstractPool.java
+++ b/src/main/java/com/dfsek/tectonic/abstraction/AbstractPool.java
@@ -2,6 +2,7 @@ package com.dfsek.tectonic.abstraction;
 
 import com.dfsek.tectonic.abstraction.exception.AbstractionException;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -32,9 +33,8 @@ public class AbstractPool {
      * @throws AbstractionException If there are errors in the configs.
      */
     public void loadAll() throws AbstractionException {
-        int i = 0;
         for(Map.Entry<String, Prototype> entry : pool.entrySet()) {
-            entry.getValue().build(this, i++);
+            entry.getValue().build(this, Collections.emptySet());
         }
     }
 

--- a/src/main/java/com/dfsek/tectonic/abstraction/AbstractValueProvider.java
+++ b/src/main/java/com/dfsek/tectonic/abstraction/AbstractValueProvider.java
@@ -11,7 +11,12 @@ import java.util.List;
  * This class holds an inheritance tree of {@link Prototype}s, and gets values from them, for loading.
  */
 public class AbstractValueProvider {
-    private final List<Prototype> tree = new ArrayList<>();
+    private final List<Layer> tree = new ArrayList<>();
+    private int layer = 0;
+
+    public AbstractValueProvider() {
+        tree.add(new Layer());
+    }
 
     /**
      * Get a value from its lowest point in the inheritance tree.
@@ -20,8 +25,9 @@ public class AbstractValueProvider {
      * @return Object loaded from the key. (Raw config object, not type adapted!)
      */
     public Object get(String key) {
-        for(Prototype p : tree) {
-            if(p.getConfig().contains(key)) return p.getConfig().get(key);
+        for(Layer p : tree) {
+            Object l = p.get(key);
+            if(l != null) return l;
         }
         return null;
     }
@@ -32,6 +38,32 @@ public class AbstractValueProvider {
      * @param prototype Prototype to add
      */
     protected void add(Prototype prototype) {
-        tree.add(prototype);
+        tree.get(layer).add(prototype);
+    }
+
+    protected int next() {
+        int l0 = layer;
+        layer++;
+        tree.add(new Layer());
+        return l0;
+    }
+
+    protected void reset(int layer) {
+        this.layer = layer;
+    }
+
+    private static final class Layer {
+        private final List<Prototype> items = new ArrayList<>();
+
+        public void add(Prototype item) {
+            items.add(item);
+        }
+
+        public Object get(String key) {
+            for(Prototype p : items) {
+                if(p.getConfig().contains(key)) return p.getConfig().get(key);
+            }
+            return null;
+        }
     }
 }

--- a/src/main/java/com/dfsek/tectonic/abstraction/Prototype.java
+++ b/src/main/java/com/dfsek/tectonic/abstraction/Prototype.java
@@ -11,9 +11,9 @@ import com.dfsek.tectonic.exception.ConfigException;
 import com.dfsek.tectonic.exception.ValidationException;
 import com.dfsek.tectonic.loading.ConfigLoader;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -25,9 +25,8 @@ import java.util.Set;
 @SuppressWarnings("unused")
 public class Prototype implements ValidatedConfigTemplate {
     private final List<Prototype> children = new ArrayList<>();
-    private final Set<Integer> UIDs = new HashSet<>();
     private final Configuration config;
-    private Prototype parent;
+    private final List<Prototype> parents = new ArrayList<>();
     private boolean isRoot = false;
 
 
@@ -36,7 +35,7 @@ public class Prototype implements ValidatedConfigTemplate {
     @SuppressWarnings("FieldMayBeFinal")
     @Value("extends")
     @Default
-    private String extend = null;
+    private List<String> extend = Collections.emptyList();
     @SuppressWarnings("FieldMayBeFinal")
     @Value("abstract")
     @Default
@@ -77,21 +76,28 @@ public class Prototype implements ValidatedConfigTemplate {
     /**
      * Build this Prototype's inheritance from an AbstractPool
      *
-     * @param pool     AbstractPool to search for parent configs.
-     * @param chainUID Unique identifier for this inheritance tree. Used to check for circular inheritance.
+     * @param pool    AbstractPool to search for parent configs.
+     * @param parents Set of parents, to check for circular inheritance.
      * @throws AbstractionException if invalid abstraction data is found.
      */
-    protected void build(AbstractPool pool, int chainUID) throws AbstractionException {
-        if(UIDs.contains(chainUID))
-            throw new CircularInheritanceException("Circular inheritance detected in config: \"" + getID() + "\", extending \"" + extend + "\", UID: " + chainUID);
-        UIDs.add(chainUID);
-        if(extend != null) {
-            Prototype parent = pool.get(extend);
+    protected void build(AbstractPool pool, Set<Prototype> parents) throws AbstractionException {
+        if(parents.contains(this))
+            throw new CircularInheritanceException("Circular inheritance detected in config: \"" + getID() + "\", extending \"" + extend + "\"");
+
+        Set<Prototype> newParents = new HashSet<>(parents);
+        newParents.add(this);
+        int index = 0;
+        for(String parentID : extend) {
+            Prototype parent = pool.get(parentID);
             if(parent == null)
-                throw new ParentNotFoundException("No such config \"" + extend + "\". Specified as parent of \"" + id + "\"");
-            this.parent = parent;
-            this.parent.build(pool, chainUID); // Build the parent, to recursively build the entire tree.
-        } else isRoot = true;
+                throw new ParentNotFoundException("No such config \"" + parentID + "\". Specified as parent of \"" + id + "\" at index " + index);
+            this.parents.add(parent);
+            parent.build(pool, newParents); // Build the parent, to recursively build the entire tree.
+            index++;
+        }
+        if(extend.size() == 0) {
+            isRoot = true;
+        }
     }
 
     /**
@@ -110,9 +116,9 @@ public class Prototype implements ValidatedConfigTemplate {
      * @return This Prototype's parent. {@code null} if the parent does not exist, or has not been loaded.
      * @see #build
      */
-    @Nullable
-    public Prototype getParent() {
-        return parent;
+    @NotNull
+    public List<Prototype> getParents() {
+        return parents;
     }
 
     /**

--- a/src/main/java/com/dfsek/tectonic/abstraction/Prototype.java
+++ b/src/main/java/com/dfsek/tectonic/abstraction/Prototype.java
@@ -29,6 +29,8 @@ public class Prototype implements ValidatedConfigTemplate {
     private final Configuration config;
     private Prototype parent;
     private boolean isRoot = false;
+
+
     @Value("id")
     private String id;
     @SuppressWarnings("FieldMayBeFinal")

--- a/src/main/java/com/dfsek/tectonic/loading/ConfigLoader.java
+++ b/src/main/java/com/dfsek/tectonic/loading/ConfigLoader.java
@@ -33,7 +33,6 @@ import com.dfsek.tectonic.util.ReflectionUtil;
 import org.yaml.snakeyaml.error.YAMLException;
 
 import java.io.InputStream;
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
@@ -65,7 +64,7 @@ public class ConfigLoader implements TypeRegistry {
         PRIMITIVES.put(void.class, Void.class);
     }
 
-    {
+    public ConfigLoader() {
         // Default primitive/wrapper loaders
         registerLoader(boolean.class, new BooleanLoader());
         registerLoader(Boolean.class, new BooleanLoader());
@@ -167,15 +166,9 @@ public class ConfigLoader implements TypeRegistry {
             int m = field.getModifiers();
             if(Modifier.isFinal(m) || Modifier.isStatic(m)) continue; // Don't mess with static/final fields.
             field.setAccessible(true); // Make field accessible so we can mess with it.
-            boolean abstractable = false;
-            boolean defaultable = false;
-            Value value = null;
-            for(Annotation annotation : field.getAnnotations()) {
-                if(annotation instanceof Abstractable) abstractable = true;
-                if(annotation instanceof Default) defaultable = true;
-                if(annotation instanceof Value) value = (Value) annotation;
-            }
-
+            boolean abstractable = field.isAnnotationPresent(Abstractable.class);
+            boolean defaultable = field.isAnnotationPresent(Default.class);
+            Value value = field.getAnnotation(Value.class);
             if(value == null) continue;
 
             Type type = field.getGenericType();

--- a/src/main/java/com/dfsek/tectonic/loading/ConfigLoader.java
+++ b/src/main/java/com/dfsek/tectonic/loading/ConfigLoader.java
@@ -11,7 +11,6 @@ import com.dfsek.tectonic.config.Configuration;
 import com.dfsek.tectonic.config.ValidatedConfigTemplate;
 import com.dfsek.tectonic.exception.ConfigException;
 import com.dfsek.tectonic.exception.LoadException;
-import com.dfsek.tectonic.exception.ReflectiveAccessException;
 import com.dfsek.tectonic.exception.ValidationException;
 import com.dfsek.tectonic.exception.ValueMissingException;
 import com.dfsek.tectonic.loading.loaders.StringLoader;
@@ -50,19 +49,6 @@ import java.util.Set;
  */
 public class ConfigLoader implements TypeRegistry {
     private final Map<Type, TypeLoader<?>> loaders = new HashMap<>();
-    private static final Map<Class<?>, Class<?>> PRIMITIVES = new HashMap<>(); // Map of primitives to their wrapper classes.
-
-    static {
-        PRIMITIVES.put(boolean.class, Boolean.class);
-        PRIMITIVES.put(byte.class, Byte.class);
-        PRIMITIVES.put(short.class, Short.class);
-        PRIMITIVES.put(char.class, Character.class);
-        PRIMITIVES.put(int.class, Integer.class);
-        PRIMITIVES.put(long.class, Long.class);
-        PRIMITIVES.put(float.class, Float.class);
-        PRIMITIVES.put(double.class, Double.class);
-        PRIMITIVES.put(void.class, Void.class);
-    }
 
     public ConfigLoader() {
         // Default primitive/wrapper loaders
@@ -181,7 +167,7 @@ public class ConfigLoader implements TypeRegistry {
                     Object loadedObject = configuration.get(value.value()); // Assign raw config object retrieved.
                     if(loaders.containsKey(raw))
                         loadedObject = loadType(type, loadedObject); // Re-assign if type is found in registry.
-                    setField(field, config, cast(field.getType(), loadedObject)); // Set the field to the loaded value.
+                    ReflectionUtil.setField(field, config, ReflectionUtil.cast(field.getType(), loadedObject)); // Set the field to the loaded value.
                 } else if(abstractable) { // If value is abstractable, try to get it from parent configs.
                     if(provider == null)
                         throw new ProviderMissingException("Attempted to load abstract value with no abstract provider registered"); // Throw exception if value is abstract and no provider is registered.
@@ -191,7 +177,7 @@ public class ConfigLoader implements TypeRegistry {
                         throw new ValueMissingException("Value \"" + value.value() + "\" was not found in the provided config, or its parents: " + configuration.getName()); // Throw exception if value is not provided, and isn't in parents.
                     }
                     abs = loadType(type, abs);
-                    setField(field, config, cast(field.getType(), abs));
+                    ReflectionUtil.setField(field, config, ReflectionUtil.cast(field.getType(), abs));
                 } else if(!defaultable) {
                     throw new ValueMissingException("Value \"" + value.value() + "\" was not found in the provided config: " + configuration.getName()); // Throw exception if value is not provided, and isn't abstractable
                 }
@@ -203,33 +189,6 @@ public class ConfigLoader implements TypeRegistry {
                 && provider == null // Validation is handled separately by AbstractConfigLoader.
                 && !((ValidatedConfigTemplate) config).validate())
             throw new ValidationException("Failed to validate config. Reason unspecified:" + configuration.getName());
-    }
-
-    /**
-     * Cast an object to a class, using primitive wrappers if available.
-     *
-     * @param clazz  Class to cast to
-     * @param object Object to cast
-     * @return Cast object.
-     */
-    @SuppressWarnings("unchecked")
-    private <T> T cast(Class<T> clazz, Object object) {
-        return (T) PRIMITIVES.getOrDefault(clazz, clazz).cast(object);
-    }
-
-    /**
-     * Set a field on an object to a value, and wrap any exceptions in a {@link ReflectiveAccessException}
-     *
-     * @param field  Field to set.
-     * @param target Object to set field on.
-     * @param value  Value of field.
-     */
-    private void setField(Field field, Object target, Object value) throws ReflectiveAccessException {
-        try {
-            field.set(target, value);
-        } catch(IllegalAccessException e) {
-            throw new ReflectiveAccessException("Failed to set field " + field + ".", e);
-        }
     }
 
     /**
@@ -266,8 +225,8 @@ public class ConfigLoader implements TypeRegistry {
 
     public <T> T loadClass(Class<T> clazz, Object o) throws LoadException {
         try {
-            if(loaders.containsKey(clazz)) return cast(clazz, loaders.get(clazz).load(clazz, o, this));
-            else return cast(clazz, o);
+            if(loaders.containsKey(clazz)) return ReflectionUtil.cast(clazz, loaders.get(clazz).load(clazz, o, this));
+            else return ReflectionUtil.cast(clazz, o);
         } catch(LoadException e) { // Rethrow LoadExceptions.
             throw e;
         } catch(Exception e) { // Catch, wrap, and rethrow exception.

--- a/src/main/java/com/dfsek/tectonic/loading/loaders/generic/ArrayListLoader.java
+++ b/src/main/java/com/dfsek/tectonic/loading/loaders/generic/ArrayListLoader.java
@@ -7,6 +7,7 @@ import com.dfsek.tectonic.loading.TypeLoader;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -17,14 +18,16 @@ import java.util.List;
 public class ArrayListLoader implements TypeLoader<ArrayList<Object>> {
     @Override
     public ArrayList<Object> load(Type t, Object c, ConfigLoader loader) throws LoadException {
-        List<Object> objectList = (List<Object>) c;
         ArrayList<Object> list = new ArrayList<>();
         if(t instanceof ParameterizedType) {
             ParameterizedType pType = (ParameterizedType) t;
             Type generic = pType.getActualTypeArguments()[0];
-            for(Object o : objectList) {
-                list.add(loader.loadType(generic, o));
-            }
+            if(c instanceof List) {
+                List<Object> objectList = (List<Object>) c;
+                for(Object o : objectList) {
+                    list.add(loader.loadType(generic, o));
+                }
+            } else return new ArrayList<>(Collections.singleton(loader.loadType(generic, c))); // Singleton
         } else throw new LoadException("Unable to load config");
         return list;
     }

--- a/src/main/java/com/dfsek/tectonic/loading/loaders/generic/HashSetLoader.java
+++ b/src/main/java/com/dfsek/tectonic/loading/loaders/generic/HashSetLoader.java
@@ -6,6 +6,7 @@ import com.dfsek.tectonic.loading.TypeLoader;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 
@@ -13,14 +14,16 @@ import java.util.List;
 public class HashSetLoader implements TypeLoader<HashSet<Object>> {
     @Override
     public HashSet<Object> load(Type t, Object c, ConfigLoader loader) throws LoadException {
-        List<Object> objectList = (List<Object>) c;
         HashSet<Object> set = new HashSet<>();
         if(t instanceof ParameterizedType) {
             ParameterizedType pType = (ParameterizedType) t;
             Type generic = pType.getActualTypeArguments()[0];
-            for(Object o : objectList) {
-                set.add(loader.loadType(generic, o));
-            }
+            if(c instanceof List) {
+                List<Object> objectList = (List<Object>) c;
+                for(Object o : objectList) {
+                    set.add(loader.loadType(generic, o));
+                }
+            } else return new HashSet<>(Collections.singleton(loader.loadType(generic, c))); // Singleton
         } else throw new LoadException("Unable to load config");
         return set;
     }

--- a/src/main/java/com/dfsek/tectonic/util/ReflectionUtil.java
+++ b/src/main/java/com/dfsek/tectonic/util/ReflectionUtil.java
@@ -1,12 +1,29 @@
 package com.dfsek.tectonic.util;
 
+import com.dfsek.tectonic.exception.ReflectiveAccessException;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Stream;
 
 public class ReflectionUtil {
+    private static final Map<Class<?>, Class<?>> PRIMITIVES = new HashMap<>(); // Map of primitives to their wrapper classes.
+
+    static {
+        PRIMITIVES.put(boolean.class, Boolean.class);
+        PRIMITIVES.put(byte.class, Byte.class);
+        PRIMITIVES.put(short.class, Short.class);
+        PRIMITIVES.put(char.class, Character.class);
+        PRIMITIVES.put(int.class, Integer.class);
+        PRIMITIVES.put(long.class, Long.class);
+        PRIMITIVES.put(float.class, Float.class);
+        PRIMITIVES.put(double.class, Double.class);
+        PRIMITIVES.put(void.class, Void.class);
+    }
+
     public static Field[] getFields(@NotNull Class<?> type) {
         Field[] result = type.getDeclaredFields();
         Class<?> parentClass = type.getSuperclass();
@@ -14,5 +31,32 @@ public class ReflectionUtil {
             result = Stream.concat(Arrays.stream(result), Arrays.stream(getFields(parentClass))).toArray(Field[]::new);
         }
         return result;
+    }
+
+    /**
+     * Cast an object to a class, using primitive wrappers if available.
+     *
+     * @param clazz  Class to cast to
+     * @param object Object to cast
+     * @return Cast object.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T cast(Class<T> clazz, Object object) {
+        return (T) PRIMITIVES.getOrDefault(clazz, clazz).cast(object);
+    }
+
+    /**
+     * Set a field on an object to a value, and wrap any exceptions in a {@link ReflectiveAccessException}
+     *
+     * @param field  Field to set.
+     * @param target Object to set field on.
+     * @param value  Value of field.
+     */
+    public static void setField(Field field, Object target, Object value) throws ReflectiveAccessException {
+        try {
+            field.set(target, value);
+        } catch(IllegalAccessException e) {
+            throw new ReflectiveAccessException("Failed to set field " + field + ".", e);
+        }
     }
 }

--- a/src/test/java/abstractconfig/AbstractTest.java
+++ b/src/test/java/abstractconfig/AbstractTest.java
@@ -18,9 +18,11 @@ public class AbstractTest {
         InputStream two = AbstractTest.class.getResourceAsStream("/abstract/two.yml");
         InputStream three = AbstractTest.class.getResourceAsStream("/abstract/three.yml");
         InputStream abs = AbstractTest.class.getResourceAsStream("/abstract/abstract.yml");
+        InputStream abs2 = AbstractTest.class.getResourceAsStream("/abstract/multi_base.yml");
+        InputStream diamond = AbstractTest.class.getResourceAsStream("/abstract/diamond.yml");
         AbstractConfigLoader loader = new AbstractConfigLoader();
         System.out.println("building...");
-        List<Template> templateList = loader.load(Arrays.asList(one, two, three, abs), Template::new);
+        List<Template> templateList = loader.load(Arrays.asList(one, two, three, abs, abs2, diamond), Template::new);
         System.out.println("built...");
 
         for(Template t : templateList) {

--- a/src/test/resources/abstract/abstract.yml
+++ b/src/test/resources/abstract/abstract.yml
@@ -1,4 +1,4 @@
-id: "ABS"
-abstract: true
-a: "value a"
-b: "value b"
+id : "ABS"
+abstract : true
+extends : "DIAMOND"
+#a: "value a"

--- a/src/test/resources/abstract/diamond.yml
+++ b/src/test/resources/abstract/diamond.yml
@@ -1,0 +1,3 @@
+id : "DIAMOND"
+abstract : true
+a : "diamond!"

--- a/src/test/resources/abstract/multi_base.yml
+++ b/src/test/resources/abstract/multi_base.yml
@@ -1,0 +1,5 @@
+id : "ABS_2"
+abstract : true
+extends : "DIAMOND"
+#a: "doesnt matter"
+b : "fdsfsad"

--- a/src/test/resources/abstract/one.yml
+++ b/src/test/resources/abstract/one.yml
@@ -1,3 +1,5 @@
 id: "ONE"
-extends: "ABS"
+extends :
+  - "ABS"
+  - "ABS_2"
 c: "value c (config 1)"


### PR DESCRIPTION
Adds the ability to use multi-inheritance in sub-configs. Values are simply pulled from the first parent to specify the required value.    

   
The `extends` key has been changed to `List<String>`, and to provide backwards compatibility, the default `List` loader has been updated to allow singleton lists defined by `key: singletonValue`. The default `Set` loader has also been updated to this behavior for parity.