### PR TITLE
Fix gradle buildscript for releases

### DIFF
--- a/buildSrc/src/main/kotlin/tectonic-common.gradle.kts
+++ b/buildSrc/src/main/kotlin/tectonic-common.gradle.kts
@@ -4,9 +4,8 @@ plugins {
 
 nyx {
     info {
-        name = "Tectonic"
+        module = "tectonic${project.path.replace(':', '-').trimEnd('-')}"
         group = "com.dfsek"
-        module = "tectonic"
         version = rootProject.version.toString()
         description = """
             Tectonic is a powerful **read-only** Java configuration library for data-driven applications.

--- a/buildSrc/src/main/kotlin/tectonic-common.gradle.kts
+++ b/buildSrc/src/main/kotlin/tectonic-common.gradle.kts
@@ -4,8 +4,7 @@ plugins {
 
 nyx {
     info {
-        module = "tectonic${project.path.replace(':', '-').trimEnd('-')}"
-        group = "com.dfsek"
+        group = "com.dfsek.tectonic"
         version = rootProject.version.toString()
         description = """
             Tectonic is a powerful **read-only** Java configuration library for data-driven applications.

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
     `tectonic-publishing`
 }
 
+nyx.info {
+    name = "Tectonic Common"
+}
+
 dependencies {
     implementation(libs.commons.io)
 }

--- a/lang/hocon/build.gradle.kts
+++ b/lang/hocon/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
     `tectonic-publishing`
 }
 
+nyx.info {
+    name = "Tectonic HOCON"
+}
+
 dependencies {
     api(projects.common)
 

--- a/lang/json/build.gradle.kts
+++ b/lang/json/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
     `tectonic-publishing`
 }
 
+nyx.info {
+    name = "Tectonic JSON"
+}
+
 dependencies {
     api(projects.common)
 

--- a/lang/toml/build.gradle.kts
+++ b/lang/toml/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
     `tectonic-publishing`
 }
 
+nyx.info {
+    name = "Tectonic TOML"
+}
+
 dependencies {
     api(projects.common)
 

--- a/lang/yaml/build.gradle.kts
+++ b/lang/yaml/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
     `tectonic-publishing`
 }
 
+nyx.info {
+    name = "Tectonic YAML"
+}
+
 dependencies {
     api(projects.common)
 


### PR DESCRIPTION
If you edit the `tectonic-common.gradle.kts`, then it's applied to all projects.

Currently, I have configured it to publish artifacts with the following names:
- `com.dfsek.tectonic:common`
- `com.dfsek.tectonic:hocon`
- `com.dfsek.tectonic:json`
- `com.dfsek.tectonic:toml`
- `com.dfsek.tectonic:yaml`

~~if you want me to switch it to use `tectonic-hocon` instead of `tectonic-lang-hocon`, that can be easily done as well.~~